### PR TITLE
Streamline authentication and add documentation for .env file

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,8 +18,10 @@ export default defineNuxtConfig({
 
   auth: {
     isEnabled: true,
-    defaultProvider: "auth0",
-    origin: process.env.AUTH_ORIGIN
+    provider: {
+      defaultProvider: "auth0",
+      type: "authjs"
+    }
   },
 
   // Tell Nuxt to load Vuetify css

--- a/template.env.md
+++ b/template.env.md
@@ -1,1 +1,8 @@
-MONGO_URL=<connection string including username and pass>
+MONGO_URL=<mongo connection string>
+AUTH0_CLIENT_ID=<from auth0 application page>
+AUTH0_CLIENT_SECRET=<from auth0 application page>
+AUTH0_ISSUER=<tenant name on auth0 application page>
+AUTH_SECRET=<some random string>
+
+AUTH_ORIGIN=<address of this server eg: http://localhost:3000>
+NEXTAUTH_URL=<Same as AUTH_ORIGIN>


### PR DESCRIPTION
Previously when attempting to access a protected page while signed out, a page would appear that just said "Sign in with Auth0". Now, that page is skipped, directing the user straight to the authentication page.

This change was made through a configuration change to `nuxt.config.json` which now correctly sets the "defaultProvider" attribute to "auth0"